### PR TITLE
Allow JSON formatter to have json compliant extra vars

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run lint
+        run: |
+          make lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run unit tests
+        run: |
+          make test-unit

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Copyright 2021 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	 http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+.PHONY: fmt
+fmt: ## Code formatting
+	gofmt -s -w .
+
+.PHONY: lint
+lint: modules  ## Code linting
+	@echo Installing linters...
+	@test -e $(GOPATH)/bin/impi || \
+		(mkdir -p $(GOPATH)/bin && \
+		curl -s https://api.github.com/repos/pavius/impi/releases/latest \
+		| grep -i "browser_download_url.*impi.*$(OS_NAME)" \
+		| cut -d : -f 2,3 \
+		| tr -d \" \
+		| wget -O $(GOPATH)/bin/impi -qi - \
+		&& chmod +x $(GOPATH)/bin/impi)
+
+	@test -e $(GOPATH)/bin/golangci-lint || \
+	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.36.0)
+
+	@echo Verifying imports...
+	$(GOPATH)/bin/impi \
+		--local github.com/nuclio/zap/ \
+		--scheme stdLocalThirdParty \
+		./...
+
+	@echo Linting...
+	$(GOPATH)/bin/golangci-lint run -v
+	@echo Done.
+
+
+.PHONY: modules
+modules: ensure-gopath  ## Download go module packages
+	@echo Getting go modules
+	@go mod download
+
+.PHONY: ensure-gopath
+ensure-gopath:  ## Ensure GOPATH env is set
+ifndef GOPATH
+	$(error GOPATH must be set)
+endif
+
+
+.PHONY: test-unit
+test-unit: ## Run unit tests
+	go test -v ./... -short
+
+.PHONY: help
+help: ## Display available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # zap
+
+A Nuclio.Logger wrapper for [zap](https://github.com/uber-go/zap)

--- a/buffer.go
+++ b/buffer.go
@@ -27,7 +27,7 @@ import (
 
 var ErrBufferPoolAllocationTimeout = errors.New("Timed out waiting for buffer logger")
 
-// a logger who outputs the records to a buffer
+// BufferLogger is a logger who outputs the records to a buffer
 type BufferLogger struct {
 	encoding string
 	Logger   *NuclioZap
@@ -79,23 +79,21 @@ func (bl *BufferLogger) GetLogEntries() ([]map[string]interface{}, error) {
 		return nil, errors.Wrap(err, "Failed to get JSON string")
 	}
 
-	unmarshalledJSONBody := []map[string]interface{}{}
+	var unmarshalledJSONBody []map[string]interface{}
 
-	err = json.Unmarshal([]byte(jsonBody), &unmarshalledJSONBody)
-	if err != nil {
+	if err := json.Unmarshal([]byte(jsonBody), &unmarshalledJSONBody); err != nil {
 		return nil, errors.Wrap(err, "Failed to unmarshal JSON body")
 	}
 
 	return unmarshalledJSONBody, nil
 }
 
-// a pool for buffer loggers
+// BufferLoggerPool is a pool for buffer loggers
 type BufferLoggerPool struct {
 	bufferLoggerChan       chan *BufferLogger
 	defaultAllocateTimeout time.Duration
 }
 
-// a pool of buffer loggers
 func NewBufferLoggerPool(numBufferLoggers int,
 	name string,
 	encoding string,

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -41,6 +41,7 @@ func (suite *BufferLoggerTestSuite) TestJSONEncodingAndStructuredVars() {
 	bufferLogger.Logger.customEncoderConfig = NewEncoderConfig()
 	bufferLogger.Logger.customEncoderConfig.JSON.VarGroupName = "testVars"
 	bufferLogger.Logger.customEncoderConfig.JSON.VarGroupMode = VarGroupModeStructured
+	bufferLogger.Logger.prepareVarsCallback = bufferLogger.Logger.prepareVarsStructured
 	suite.verifyLoggedJSONEntries(bufferLogger)
 }
 

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -27,42 +27,21 @@ type BufferLoggerTestSuite struct {
 	suite.Suite
 }
 
-func (suite *BufferLoggerTestSuite) TestJSONencoding() {
+func (suite *BufferLoggerTestSuite) TestJSONEncoding() {
 	bufferLogger, err := NewBufferLogger("test", "json", InfoLevel)
 	suite.Require().NoError(err, "Failed creating buffer logger")
 
-	// write a few entries
-	bufferLogger.Logger.Debug("Unstructured %s", "debug")
-	bufferLogger.Logger.DebugWith("Structured debug", "mode", "debug")
-	bufferLogger.Logger.Info("Unstructured %s", "info")
-	bufferLogger.Logger.InfoWith("Structured info", "mode", "info")
-	bufferLogger.Logger.Warn("Unstructured %s", "warn")
-	bufferLogger.Logger.WarnWith("Structured warn", "mode", "warn")
-	bufferLogger.Logger.Error("Unstructured %s", "error")
-	bufferLogger.Logger.ErrorWith("Structured error", "mode", "error")
+	suite.verifyLoggedJSONEntries(bufferLogger)
+}
 
-	// get log entries
-	logEntries, err := bufferLogger.GetLogEntries()
-	suite.Require().NoError(err, "Failed to get log entries")
+func (suite *BufferLoggerTestSuite) TestJSONEncodingAndStructuredVars() {
+	bufferLogger, err := NewBufferLogger("test", "json", InfoLevel)
+	suite.Require().NoError(err, "Failed creating buffer logger")
 
-	// verify (debug should be filtered)
-	suite.Require().Equal("Unstructured info", logEntries[0]["message"])
-	suite.Require().Equal("info", logEntries[0]["level"])
-	suite.Require().Equal("Structured info", logEntries[1]["message"])
-	suite.Require().Equal("info", logEntries[1]["level"])
-	suite.Require().Equal("info", logEntries[1]["mode"])
-
-	suite.Require().Equal("Unstructured warn", logEntries[2]["message"])
-	suite.Require().Equal("warn", logEntries[2]["level"])
-	suite.Require().Equal("Structured warn", logEntries[3]["message"])
-	suite.Require().Equal("warn", logEntries[3]["level"])
-	suite.Require().Equal("warn", logEntries[3]["mode"])
-
-	suite.Require().Equal("Unstructured error", logEntries[4]["message"])
-	suite.Require().Equal("error", logEntries[4]["level"])
-	suite.Require().Equal("Structured error", logEntries[5]["message"])
-	suite.Require().Equal("error", logEntries[5]["level"])
-	suite.Require().Equal("error", logEntries[5]["mode"])
+	bufferLogger.Logger.customEncoderConfig = NewEncoderConfig()
+	bufferLogger.Logger.customEncoderConfig.JSON.VarGroupName = "testVars"
+	bufferLogger.Logger.customEncoderConfig.JSON.VarGroupMode = VarGroupModeStructured
+	suite.verifyLoggedJSONEntries(bufferLogger)
 }
 
 func (suite *BufferLoggerTestSuite) TestEmptyJSONEncoding() {
@@ -85,6 +64,65 @@ func (suite *BufferLoggerTestSuite) TestGetJSONWithNonJSONEncoding() {
 	logEntries, err := bufferLogger.GetLogEntries()
 	suite.Require().Error(err)
 	suite.Require().Nil(logEntries)
+}
+
+func (suite *BufferLoggerTestSuite) verifyLoggedJSONEntries(bufferLogger *BufferLogger) {
+
+	varsStructured := false
+	varsGroupName := ""
+	if bufferLogger.Logger.customEncoderConfig != nil &&
+		bufferLogger.Logger.customEncoderConfig.JSON.VarGroupMode == VarGroupModeStructured {
+		varsStructured = true
+		varsGroupName = bufferLogger.Logger.customEncoderConfig.JSON.VarGroupName
+	}
+
+	// write a few entries
+	bufferLogger.Logger.Debug("Unstructured %s", "debug")
+	bufferLogger.Logger.DebugWith("Structured debug", "mode", "debug")
+	bufferLogger.Logger.Info("Unstructured %s", "info")
+	bufferLogger.Logger.InfoWith("Structured info", "mode", "info")
+	bufferLogger.Logger.Warn("Unstructured %s", "warn")
+	bufferLogger.Logger.WarnWith("Structured warn", "mode", "warn")
+	bufferLogger.Logger.Error("Unstructured %s", "error")
+	bufferLogger.Logger.ErrorWith("Structured error", "mode", "error")
+
+	// get log entries
+	logEntries, err := bufferLogger.GetLogEntries()
+	suite.Require().NoError(err, "Failed to get log entries")
+
+	// verify (debug should be filtered)
+	suite.Require().Equal("Unstructured info", logEntries[0]["message"])
+	suite.Require().Equal("info", logEntries[0]["level"])
+	suite.Require().Equal("Structured info", logEntries[1]["message"])
+	suite.Require().Equal("info", logEntries[1]["level"])
+
+	if varsStructured {
+		suite.Require().Equal(map[string]interface{}{"mode": "info"}, logEntries[1][varsGroupName])
+	} else {
+		suite.Require().Equal("info", logEntries[1]["mode"])
+
+	}
+
+	suite.Require().Equal("Unstructured warn", logEntries[2]["message"])
+	suite.Require().Equal("warn", logEntries[2]["level"])
+	suite.Require().Equal("Structured warn", logEntries[3]["message"])
+	suite.Require().Equal("warn", logEntries[3]["level"])
+
+	if varsStructured {
+		suite.Require().Equal(map[string]interface{}{"mode": "warn"}, logEntries[3][varsGroupName])
+	} else {
+		suite.Require().Equal("warn", logEntries[3]["mode"])
+	}
+
+	suite.Require().Equal("Unstructured error", logEntries[4]["message"])
+	suite.Require().Equal("error", logEntries[4]["level"])
+	suite.Require().Equal("Structured error", logEntries[5]["message"])
+	suite.Require().Equal("error", logEntries[5]["level"])
+	if varsStructured {
+		suite.Require().Equal(map[string]interface{}{"mode": "error"}, logEntries[5][varsGroupName])
+	} else {
+		suite.Require().Equal("error", logEntries[5]["mode"])
+	}
 }
 
 type BufferLoggerPoolTestSuite struct {

--- a/logger.go
+++ b/logger.go
@@ -305,7 +305,7 @@ func (nz *NuclioZap) DebugWithCtx(ctx context.Context, format interface{}, vars 
 
 // Flush flushes the log
 func (nz *NuclioZap) Flush() {
-	nz.Sync()
+	nz.Sync() // nolint: errcheck
 }
 
 // GetChild returned a named child logger

--- a/logger.go
+++ b/logger.go
@@ -440,10 +440,11 @@ func (nz *NuclioZap) prepareVars(vars []interface{}) []interface{} {
 	}
 
 	formattedVars := ""
+	delimiter := ", "
 
 	// create key=value pairs
 	for varIndex := 0; varIndex < len(vars); varIndex += 2 {
-		formattedVars += fmt.Sprintf("%s=%+v || ", vars[varIndex], vars[varIndex+1])
+		formattedVars += fmt.Sprintf(`"%s": "%+v"%s`, vars[varIndex], vars[varIndex+1], delimiter)
 	}
 
 	// if nothing was created, don't generate a group
@@ -451,6 +452,8 @@ func (nz *NuclioZap) prepareVars(vars []interface{}) []interface{} {
 		return []interface{}{}
 	}
 
+	// let it look like a json, trim last `, `
+	formattedVars = fmt.Sprintf("{%s}", formattedVars[:len(formattedVars)-len(delimiter)])
 	return []interface{}{
 		nz.customEncoderConfig.JSON.VarGroupName,
 		formattedVars[:len(formattedVars)-4],

--- a/logger.go
+++ b/logger.go
@@ -439,12 +439,11 @@ func (nz *NuclioZap) prepareVars(vars []interface{}) []interface{} {
 		panic("Odd number of logging vars - must be key/value")
 	}
 
-	formattedVars := ""
-	delimiter := ", "
+	formattedVars := map[string]interface{}{}
 
 	// create key=value pairs
 	for varIndex := 0; varIndex < len(vars); varIndex += 2 {
-		formattedVars += fmt.Sprintf(`"%s": "%+v"%s`, vars[varIndex], vars[varIndex+1], delimiter)
+		formattedVars[fmt.Sprintf("%s", vars[varIndex])] = vars[varIndex+1]
 	}
 
 	// if nothing was created, don't generate a group
@@ -453,9 +452,8 @@ func (nz *NuclioZap) prepareVars(vars []interface{}) []interface{} {
 	}
 
 	// let it look like a json, trim last `, `
-	formattedVars = fmt.Sprintf("{%s}", formattedVars[:len(formattedVars)-len(delimiter)])
 	return []interface{}{
 		nz.customEncoderConfig.JSON.VarGroupName,
-		formattedVars[:len(formattedVars)-4],
+		formattedVars,
 	}
 }


### PR DESCRIPTION
Motivation - Having a `json` logger that uses a JSON compliant extra vars encoding.

This PR extends prepare vars capabilities by adding `VarGroupMode` of `encoded` \ `structured`

When it is set to `encoded` (default) it encodes the extra vars (e.g.: `DebugWith("message", "this-is-extra-var-key", "this-is-extra-var-value")`) to set of key=value pairs.

When it is set to `structured`, it uses a JSON compliant structure of `"key": "value"` for each pair of var.

 On top of that, added `Makefile` and `CI` for unit testings.