### PR TITLE
Fixes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -323,6 +323,7 @@ func (nz *NuclioZap) GetChild(name string) logger.Logger {
 		SugaredLogger:       nz.Named(name),
 		encoding:            nz.encoding,
 		customEncoderConfig: nz.customEncoderConfig,
+		prepareVarsCallback: nz.prepareVarsCallback,
 	}
 }
 
@@ -483,12 +484,13 @@ func (nz *NuclioZap) prepareVarsStructured(vars []interface{}) interface{} {
 }
 
 func (nz *NuclioZap) prepareVarsFlattened(vars []interface{}) interface{} {
-	formattedVars := ""
+	var s strings.Builder
+	delimiter := " || "
 
 	// create key=value pairs
 	for varIndex := 0; varIndex < len(vars); varIndex += 2 {
-		formattedVars += fmt.Sprintf("%s=%+v || ", vars[varIndex], vars[varIndex+1])
+		s.WriteString(fmt.Sprintf("%s=%+v%s", vars[varIndex], vars[varIndex+1], delimiter))
 	}
 
-	return formattedVars
+	return s.String()[:s.Len()-len(delimiter)]
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,45 @@
+package nucliozap
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type LoggerTestSuite struct {
+	suite.Suite
+}
+
+func (suite *LoggerTestSuite) TestPrepareVars() {
+	zap := NuclioZap{}
+	vars := []interface{}{
+		"some", "thing",
+		"something", "else",
+	}
+	encodedVars := zap.prepareVarsFlattened(vars)
+	suite.Require().Equal("some=thing || something=else", encodedVars)
+
+	structuredVars := zap.prepareVarsStructured(vars)
+	suite.Require().Equal(map[string]interface{}{
+		"some":      "thing",
+		"something": "else",
+	}, structuredVars)
+}
+
+func (suite *LoggerTestSuite) TestGetChild() {
+	writer := &bytes.Buffer{}
+	encoderConfig := NewEncoderConfig()
+	encoderConfig.JSON.VarGroupName = "extra"
+	encoderConfig.JSON.VarGroupMode = VarGroupModeStructured
+	zap, err := NewNuclioZap("test", "json", encoderConfig, writer, writer, DebugLevel)
+	suite.Require().NoError(err)
+	childLogger := zap.GetChild("some-child")
+	childLogger.InfoWith("Test", "some", "thing")
+	suite.Require().Contains(writer.String(), `"extra":{"some":"thing"}`)
+	suite.Require().Contains(writer.String(), `"name":"test.some-child"`)
+}
+
+func TestLoggerTestSuite(t *testing.T) {
+	suite.Run(t, new(LoggerTestSuite))
+}


### PR DESCRIPTION
- fixed `getChild` not populated the `prepareVarsCallback` caused panic
- flattened mode did not trimmed last delimiter