### PR TITLE
Use faster encoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nuclio/zap
 go 1.17
 
 require (
+	github.com/goccy/go-json v0.9.3
 	github.com/liranbg/uberzap v1.20.0-nuclio.1
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/nuclio/errors v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.9.3 h1:VYKeLtdIQXWaeTZy5JNGZbVui5ck7Vf5MlWEcflqz0s=
+github.com/goccy/go-json v0.9.3/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/logger.go
+++ b/logger.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	gojson "github.com/goccy/go-json"
 	"github.com/liranbg/uberzap"
 	"github.com/liranbg/uberzap/zapcore"
 	"github.com/logrusorgru/aurora/v3"
@@ -419,6 +420,9 @@ func (nz *NuclioZap) getEncoderConfig(encoding string, encoderConfig *EncoderCon
 		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeCaller:   func(zapcore.EntryCaller, zapcore.PrimitiveArrayEncoder) {},
 		EncodeName:     zapcore.FullNameEncoder,
+		NewReflectedEncoder: func(writer io.Writer) zapcore.ReflectedEncoder {
+			return gojson.NewEncoder(writer)
+		},
 	}
 }
 


### PR DESCRIPTION
Using https://github.com/goccy/go-json as a JSON encoder benefits logger with increased performance by ~30%

from benchmark tests
```
goos: darwin
goarch: amd64
pkg: github.com/nuclio/zap
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkLogger
BenchmarkLogger-16                 	  279752	      3900 ns/op
BenchmarkLoggerCustomEncoder
BenchmarkLoggerCustomEncoder-16    	  360952	      2949 ns/op
PASS
```

For this test, Ive built the logger to use the custom encoder and one using the stdlib
each logger used "json" formatter and did the following
```
for i := 0; i < b.N; i++ {
  loggerInstance.InfoWith("Check", "customEncoderConfig", *loggerInstance.customEncoderConfig)
}
```