### PR TITLE
Delegate reflected encoder to callee

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nuclio/zap
 go 1.17
 
 require (
-	github.com/goccy/go-json v0.9.3
 	github.com/liranbg/uberzap v1.20.0-nuclio.1
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/nuclio/errors v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZx
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/goccy/go-json v0.9.3 h1:VYKeLtdIQXWaeTZy5JNGZbVui5ck7Vf5MlWEcflqz0s=
-github.com/goccy/go-json v0.9.3/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/logger.go
+++ b/logger.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	gojson "github.com/goccy/go-json"
 	"github.com/liranbg/uberzap"
 	"github.com/liranbg/uberzap/zapcore"
 	"github.com/logrusorgru/aurora/v3"
@@ -46,6 +45,7 @@ type EncoderConfigJSON struct {
 	VarGroupMode      VarGroupMode
 	TimeFieldName     string
 	TimeFieldEncoding string
+	ReflectedEncoder  func(writer io.Writer) zapcore.ReflectedEncoder
 }
 
 type EncoderConfigConsole struct {
@@ -63,6 +63,7 @@ func NewEncoderConfig() *EncoderConfig {
 			TimeFieldName:     "time",
 			TimeFieldEncoding: "epoch-millis",
 			VarGroupMode:      DefaultVarGroupMode,
+			ReflectedEncoder:  nil,
 		},
 	}
 }
@@ -408,21 +409,19 @@ func (nz *NuclioZap) getEncoderConfig(encoding string, encoderConfig *EncoderCon
 	}
 
 	return &zapcore.EncoderConfig{
-		TimeKey:        encoderConfig.JSON.TimeFieldName,
-		NameKey:        "name",
-		LevelKey:       "level",
-		CallerKey:      "",
-		MessageKey:     "message",
-		StacktraceKey:  "stack",
-		LineEnding:     encoderConfig.JSON.LineEnding,
-		EncodeLevel:    zapcore.LowercaseLevelEncoder,
-		EncodeTime:     timeEncoder,
-		EncodeDuration: zapcore.SecondsDurationEncoder,
-		EncodeCaller:   func(zapcore.EntryCaller, zapcore.PrimitiveArrayEncoder) {},
-		EncodeName:     zapcore.FullNameEncoder,
-		NewReflectedEncoder: func(writer io.Writer) zapcore.ReflectedEncoder {
-			return gojson.NewEncoder(writer)
-		},
+		TimeKey:             encoderConfig.JSON.TimeFieldName,
+		NameKey:             "name",
+		LevelKey:            "level",
+		CallerKey:           "",
+		MessageKey:          "message",
+		StacktraceKey:       "stack",
+		LineEnding:          encoderConfig.JSON.LineEnding,
+		EncodeLevel:         zapcore.LowercaseLevelEncoder,
+		EncodeTime:          timeEncoder,
+		EncodeDuration:      zapcore.SecondsDurationEncoder,
+		EncodeCaller:        func(zapcore.EntryCaller, zapcore.PrimitiveArrayEncoder) {},
+		EncodeName:          zapcore.FullNameEncoder,
+		NewReflectedEncoder: encoderConfig.JSON.ReflectedEncoder,
 	}
 }
 


### PR DESCRIPTION
Unfortunate we've found that https://github.com/goccy/go-json is not stable enough.

Observed a panic during `nuclio` CI tests

```
    suite.go:63: test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 637 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
        github.com/stretchr/testify/suite.failOnPanic(0xc000b3f380)
        	/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:63 +0x3e
        panic({0x1c48fc0, 0x32a05b0})
        	/usr/local/go/src/runtime/panic.go:1038 +0x215
        github.com/goccy/go-json/internal/encoder/vm.Run(0xc000d5a4e0, {0xc000c47400, 0x0, 0x400}, 0xc000272d20)
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/internal/encoder/vm/vm.go:25 +0xb4
        github.com/goccy/go-json.encodeRunCode(0x0, {0xc000c47400, 0x2, 0xc000c7a0c0}, 0xc000da2728)
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/encode.go:308 +0x68
        github.com/goccy/go-json.encode(0xc000d5a4e0, {0x1af27c0, 0xc000d85800})
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/encode.go:233 +0x21c
        github.com/goccy/go-json.(*Encoder).encodeWithOption(0xc000c7a0c0, 0xc000d5a4e0, {0x1af27c0, 0xc000d85800}, {0x0, 0x0, 0x40f027})
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/encode.go:75 +0xfd
        github.com/goccy/go-json.(*Encoder).EncodeWithOption(0xfb40c6, {0x1af27c0, 0xc000d85800}, {0x0, 0x0, 0x0})
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/encode.go:41 +0x92
        github.com/goccy/go-json.(*Encoder).Encode(0xc0009e85c0, {0x1af27c0, 0xc000d85800})
        	/go/pkg/mod/github.com/goccy/go-json@v0.9.3/encode.go:33 +0x2a
        github.com/liranbg/uberzap/zapcore.(*jsonEncoder).encodeReflected(0xc0009e85c0, {0x1af27c0, 0xc000d85800})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/json_encoder.go:174 +0x5c
        github.com/liranbg/uberzap/zapcore.(*jsonEncoder).AddReflected(0xc0009e85c0, {0x1ed2090, 0x6}, {0x1af27c0, 0xc000d85800})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/json_encoder.go:182 +0x45
        github.com/liranbg/uberzap/zapcore.Field.AddTo({{0x1ed2090, 0x6}, 0x17, 0x0, {0x0, 0x0}, {0x1af27c0, 0xc000d85800}}, {0x229bc20, 0xc0009e85c0})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/field.go:170 +0x894
        github.com/liranbg/uberzap/zapcore.addFields({0x229bc20, 0xc0009e85c0}, {0xc0008c8b80, 0x1, 0x40ecd4})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/field.go:210 +0xe6
        github.com/liranbg/uberzap/zapcore.(*jsonEncoder).EncodeEntry(0xc000db0180, {0x0, {0xc071c874646a7275, 0x256a86a89e, 0x32c99e0}, {0x1ed3bcc, 0x8}, {0x1edb1ae, 0xe}, {0x1, ...}, ...}, ...)
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/json_encoder.go:422 +0x671
        github.com/liranbg/uberzap/zapcore.(*ioCore).Write(0xc000776f60, {0x0, {0xc071c874646a7275, 0x256a86a89e, 0x32c99e0}, {0x1ed3bcc, 0x8}, {0x1edb1ae, 0xe}, {0x1, ...}, ...}, ...)
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/core.go:86 +0x7c
        github.com/liranbg/uberzap/zapcore.(*CheckedEntry).Write(0xc00038b980, {0xc0008c8b80, 0x1, 0x2})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/zapcore/entry.go:220 +0x1d9
        github.com/liranbg/uberzap.(*SugaredLogger).log(0xc000d06918, 0x0, {0x1edb1ae, 0xe}, {0x0, 0x0, 0x0}, {0xc00007b680, 0x2, 0x2})
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/sugar.go:227 +0xee
        github.com/liranbg/uberzap.(*SugaredLogger).Infow(...)
        	/go/pkg/mod/github.com/liranbg/uberzap@v1.20.0-nuclio.1/sugar.go:179
        github.com/nuclio/zap.(*NuclioZap).InfoWith(0xc000a71d60, {0x1b5bd60, 0x21fc010}, {0xc00007b680, 0xc000da2ea8, 0x40f027})
        	/go/pkg/mod/github.com/nuclio/zap@v0.1.1/logger.go:291 +0x8f
        github.com/nuclio/zap.(*MuxLogger).InfoWith(0xc000339200, {0x1b5bd60, 0x21fc010}, {0xc00007b680, 0x2, 0x2})
        	/go/pkg/mod/github.com/nuclio/zap@v0.1.1/mux.go:116 +0xa7
        github.com/nuclio/nuclio/pkg/processor/build.(*Builder).Build(0xc000339200, 0xc00094b1a0)
        	/nuclio/pkg/processor/build/builder.go:275 +0x735
        github.com/nuclio/nuclio/pkg/platform/abstract.(*Platform).CreateFunctionBuild(0xc000274ab0, 0xc000d85000)
        	/nuclio/pkg/platform/abstract/platform.go:117 +0xa5
        github.com/nuclio/nuclio/pkg/platform/abstract.(*Platform).HandleDeployFunction(0xc000274ab0, {0x224e550, 0xc0000420a0}, 0x0, 0xc000710900, 0xc000776fc0, 0xc000f21160)
        	/nuclio/pkg/platform/abstract/platform.go:152 +0x46a
        github.com/nuclio/nuclio/pkg/platform/kube.(*Platform).CreateFunction(0xc0009ed180, {0x224e550, 0xc0000420a0}, 0xc000710900)
        	/nuclio/pkg/platform/kube/platform.go:428 +0x554
        github.com/nuclio/nuclio/pkg/processor/test/suite.(*TestSuite).deployFunction(0xc000952600, 0x70, 0xc000f21448)
        	/nuclio/pkg/processor/test/suite/suite.go:617 +0x4a
        github.com/nuclio/nuclio/pkg/processor/test/suite.(*TestSuite).deployFunctionPopulateMissingFields(0xc000952600, 0xc000710900, 0x68)
        	/nuclio/pkg/processor/test/suite/suite.go:610 +0xa5
        github.com/nuclio/nuclio/pkg/processor/test/suite.(*TestSuite).DeployFunctionExpectError(0xc000952600, 0xc000d02e10, 0x4e)
        	/nuclio/pkg/processor/test/suite/suite.go:318 +0x25
        github.com/nuclio/nuclio/pkg/platform/kube/monitoring/test.(*FunctionMonitoringTestSuite).TestRecoveryAfterDeployError(0xc000952600)
        	/nuclio/pkg/platform/kube/monitoring/test/function_test.go:148 +0x573
        reflect.Value.call({0xc0009dfbc0, 0xc000116718, 0xc001085d58}, {0x1ed0808, 0x4}, {0xc001085e70, 0x1, 0xc001085d80})
        	/usr/local/go/src/reflect/value.go:543 +0x814
        reflect.Value.Call({0xc0009dfbc0, 0xc000116718, 0xc000952600}, {0xc001085e70, 0x1, 0x1})
        	/usr/local/go/src/reflect/value.go:339 +0xc5
        github.com/stretchr/testify/suite.Run.func1(0xc000b3f380)
        	/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:158 +0x4b6
        testing.tRunner(0xc000b3f380, 0xc000719680)
        	/usr/local/go/src/testing/testing.go:1259 +0x102
        created by testing.(*T).Run
        	/usr/local/go/src/testing/testing.go:1306 +0x35a
```