### PR TITLE
Enrich vars with context ID

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ "1.20", "stable" ]
+        go: [ "1.23", "stable" ]
     steps:
       - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint: modules  ## Code linting
 		&& chmod +x $(GOPATH)/bin/impi)
 
 	@test -e $(GOPATH)/bin/golangci-lint || \
-	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.54.2)
+	  	(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.63.4)
 
 	@echo Verifying imports...
 	$(GOPATH)/bin/impi \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuclio/zap
 
-go 1.20
+go 1.23
 
 require (
 	github.com/logrusorgru/aurora/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -23,6 +24,7 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=

--- a/logger.go
+++ b/logger.go
@@ -39,9 +39,11 @@ const (
 
 const DefaultVarGroupMode = VarGroupModeFlattened
 
+type ContextKey int
+
 const (
-	RequestIDKey = "RequestID"
-	ContextIDKey = "ContextID"
+	RequestIDKey ContextKey = iota
+	ContextIDKey
 )
 
 type EncoderConfigJSON struct {
@@ -439,9 +441,12 @@ func (nz *NuclioZap) addContextToVars(ctx context.Context, vars []interface{}) [
 		return vars
 	}
 
-	for key, name := range map[string]string{
+	for key, name := range map[interface{}]string{
 		RequestIDKey: "requestID",
 		ContextIDKey: "ctx",
+
+		// For backwards compatibility
+		"RequestID": "requestID",
 	} {
 		// get context value
 		value := ctx.Value(key)

--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -453,6 +454,11 @@ func (nz *NuclioZap) addContextToVars(ctx context.Context, vars []interface{}) [
 
 		// if not set, don't add it to vars
 		if value == nil || value == "" {
+			continue
+		}
+
+		// don't override the value if it's already set
+		if slices.Contains(vars, interface{}(name)) {
 			continue
 		}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -95,6 +95,17 @@ func (suite *LoggerTestSuite) TestAddContextToVars() {
 	suite.Require().Contains(vars, "some")
 	suite.Require().Contains(vars, "thing")
 
+	// validate it skips existing values
+	existingRequestID := "987654"
+	vars = zap.addContextToVars(ctx, []interface{}{"some", "thing", "requestID", existingRequestID})
+	for _, expected := range []string{
+		"requestID",
+		existingRequestID,
+		"ctx",
+		contextID,
+	} {
+		suite.Require().Contains(vars, expected)
+	}
 }
 
 func TestLoggerTestSuite(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -82,26 +82,28 @@ func (suite *LoggerTestSuite) TestAddContextToVars() {
 	contextID := "abcdef"
 	ctx = context.WithValue(ctx, RequestIDKey, requestID)
 	ctx = context.WithValue(ctx, ContextIDKey, contextID)
+	ctx = context.WithValue(ctx, "RequestID", "asdfgh") // nolint: staticcheck
 
 	vars := zap.addContextToVars(ctx, []interface{}{"some", "thing"})
-	for _, expected := range []string{
-		"requestID",
+	for _, expected := range []interface{}{
+		RequestIDKey,
 		requestID,
-		"ctx",
+		ContextIDKey,
 		contextID,
 	} {
 		suite.Require().Contains(vars, expected)
 	}
+	suite.Require().NotContains(vars, "RequestID")
 	suite.Require().Contains(vars, "some")
 	suite.Require().Contains(vars, "thing")
 
 	// validate it skips existing values
 	existingRequestID := "987654"
 	vars = zap.addContextToVars(ctx, []interface{}{"some", "thing", "requestID", existingRequestID})
-	for _, expected := range []string{
-		"requestID",
+	for _, expected := range []interface{}{
+		RequestIDKey,
 		existingRequestID,
-		"ctx",
+		ContextIDKey,
 		contextID,
 	} {
 		suite.Require().Contains(vars, expected)


### PR DESCRIPTION
If a context object has a `ContextID` value, enrich the logged vars with it and call it `ctx`.

Additionally - Bump go to 1.23