### PR TITLE
Log context vars as strings

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -472,11 +472,8 @@ func (nz *NuclioZap) addContextToVars(ctx context.Context, vars []interface{}) [
 			continue
 		}
 
-		// create a slice 2 slots larger
-		varsWithContext := make([]interface{}, 0, len(vars)+2)
-		varsWithContext = append(varsWithContext, key)
-		varsWithContext = append(varsWithContext, value)
-		vars = append(varsWithContext, vars...)
+		// append key and value to the beginning of the vars
+		vars = append([]interface{}{string(key), value}, vars...)
 	}
 
 	return vars

--- a/logger_test.go
+++ b/logger_test.go
@@ -86,9 +86,9 @@ func (suite *LoggerTestSuite) TestAddContextToVars() {
 
 	vars := zap.addContextToVars(ctx, []interface{}{"some", "thing"})
 	for _, expected := range []interface{}{
-		RequestIDKey,
+		string(RequestIDKey),
 		requestID,
-		ContextIDKey,
+		string(ContextIDKey),
 		contextID,
 	} {
 		suite.Require().Contains(vars, expected)
@@ -101,9 +101,9 @@ func (suite *LoggerTestSuite) TestAddContextToVars() {
 	existingRequestID := "987654"
 	vars = zap.addContextToVars(ctx, []interface{}{"some", "thing", "requestID", existingRequestID})
 	for _, expected := range []interface{}{
-		RequestIDKey,
+		string(RequestIDKey),
 		existingRequestID,
-		ContextIDKey,
+		string(ContextIDKey),
 		contextID,
 	} {
 		suite.Require().Contains(vars, expected)


### PR DESCRIPTION
As per zap's limitaion: https://github.com/uber-go/zap/blob/master/sugar.go#L33 - 
```
Ignored key-value pairs with non-string keys
```

So, log the context keys as strings.